### PR TITLE
fix error: Cannot use 'in' operator to search for 'property' in 'value'

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ api.get = function get (obj, pointer) {
         refTokens = api.parse(pointer);
     while (refTokens.length) {
         tok = refTokens.shift();
-        if (!(tok in obj)) {
+        if (!(typeof obj == 'object' && tok in obj)) {
             throw new Error('Invalid reference token: ' + tok);
         }
         obj = obj[tok];


### PR DESCRIPTION
If the reached value is not an object "in" operator cannot be used to check for property presence.