### PR TITLE
accept array of reference tokens as a pointer

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -33,6 +33,8 @@ var pointer = require('json-pointer');
 
 Looks up a JSON pointer in an object.
 
+Array of reference tokens, e.g. returned by api.parse, can be passed as a pointer to .get, .set and .remove methods.
+
 ```Javascript
 var obj = {
     example: {
@@ -55,7 +57,7 @@ pointer.set(obj, '/example/bla', 'hello');
 
 ### .remove(object, pointer)
 
-Removes an attribute of object referenced by pointer
+Removes an attribute of object referenced by pointer.
 
 ```Javascript
 var obj = {

--- a/index.js
+++ b/index.js
@@ -10,8 +10,8 @@ module.exports = api;
  * Calls `.set` when also called with `value`.
  * If only supplied `object`, returns a partially applied function, mapped to the object.
  *
- * @param obj
- * @param pointer
+ * @param {Object} obj
+ * @param {String|Array} pointer
  * @param value
  * @returns {*}
  */
@@ -41,13 +41,13 @@ function api (obj, pointer, value) {
 /**
  * Lookup a json pointer in an object
  *
- * @param obj
- * @param pointer
+ * @param {Object} obj
+ * @param {String|Array} pointer
  * @returns {*}
  */
 api.get = function get (obj, pointer) {
     var tok,
-        refTokens = api.parse(pointer);
+        refTokens = Array.isArray(pointer) ? pointer : api.parse(pointer);
     while (refTokens.length) {
         tok = refTokens.shift();
         if (!(typeof obj == 'object' && tok in obj)) {
@@ -61,12 +61,12 @@ api.get = function get (obj, pointer) {
 /**
  * Sets a value on an object
  *
- * @param obj
- * @param pointer
+ * @param {Object} obj
+ * @param {String|Array} pointer
  * @param value
  */
 api.set = function set (obj, pointer, value) {
-    var refTokens = api.parse(pointer),
+    var refTokens = Array.isArray(pointer) ? pointer : api.parse(pointer),
         tok,
         nextTok = refTokens[0];
     while (refTokens.length > 1) {
@@ -95,11 +95,11 @@ api.set = function set (obj, pointer, value) {
 /**
  * Removes an attribute
  *
- * @param obj
- * @param pointer
+ * @param {Object} obj
+ * @param {String|Array} pointer
  */
 api.remove = function (obj, pointer) {
-    var refTokens = api.parse(pointer);
+    var refTokens = Array.isArray(pointer) ? pointer : api.parse(pointer);
     var finalToken = refTokens.pop();
     if (finalToken === undefined) {
         throw new Error('Invalid JSON pointer for remove: "' + pointer + '"');

--- a/test/test.js
+++ b/test/test.js
@@ -14,11 +14,13 @@ describe('json-api', function () {
     'use strict';
 
     var rfcExample,
-        rfcValues;
+        rfcValues,
+        rfcParsed;
 
     function resetExamples() {
         rfcExample = {
             "foo":      ["bar", "baz"],
+            "bar":      {"baz": 10},
             "":         0,
             "a/b":      1,
             "c%d":      2,
@@ -34,6 +36,8 @@ describe('json-api', function () {
             "":         rfcExample,
             "/foo":     rfcExample.foo,
             "/foo/0":   "bar",
+            "/bar":     rfcExample.bar,
+            "/bar/baz": 10,
             "/":        0,
             "/a~1b":    1,
             "/c%d":     2,
@@ -43,6 +47,23 @@ describe('json-api', function () {
             "/k\"l":    6,
             "/ ":       7,
             "/m~0n":    8
+        };
+
+        rfcParsed = {
+            "":         { tokens: [],             value: rfcExample },
+            "/foo":     { tokens: ["foo"],        value: rfcExample.foo },
+            "/foo/0":   { tokens: ["foo", "0"],   value: "bar" },
+            "/bar":     { tokens: ["bar"],        value: rfcExample.bar },
+            "/bar/baz": { tokens: ["bar", "baz"], value: 10 },
+            "/":        { tokens: [""],           value: 0 },
+            "/a~1b":    { tokens: ["a/b"],        value: 1 },
+            "/c%d":     { tokens: ["c%d"],        value: 2 },
+            "/e^f":     { tokens: ["e^f"],        value: 3 },
+            "/g|h":     { tokens: ["g|h"],        value: 4 },
+            "/i\\j":    { tokens: ["i\\j"],       value: 5 },
+            "/k\"l":    { tokens: ["k\"l"],       value: 6 },
+            "/ ":       { tokens: [" "],          value: 7 },
+            "/m~0n":    { tokens: ["m~n"],        value: 8 }
         };
     }
     resetExamples();
@@ -62,6 +83,14 @@ describe('json-api', function () {
             });
         });
 
+        each(Object.keys(rfcParsed), function (p) {
+            var tokens = rfcParsed[p].tokens;
+            it('should work for ' + JSON.stringify(tokens), function () {
+                var expectedValue = rfcParsed[p].value;
+                pointer.get(rfcExample, tokens).should.equal(expectedValue);
+            });
+        });
+
         it('should work for with inherited properties', function () {
             function O () {}
             O.prototype.x = 10;
@@ -72,7 +101,7 @@ describe('json-api', function () {
 
     describe('#set', function () {
 
-        it('should set a value on an object', function () {
+        it('should set a value on an object with pointer', function () {
             var obj = {
                 existing: 'bla'
             };
@@ -81,7 +110,16 @@ describe('json-api', function () {
             obj['new-value'].bla.should.equal('expected');
         });
 
-        it('should work on first level', function () {
+        it('should set a value on an object with tokens', function () {
+            var obj = {
+                existing: 'bla'
+            };
+
+            pointer.set(obj, ['new-value', 'bla'], 'expected');
+            obj['new-value'].bla.should.equal('expected');
+        });
+
+        it('should work on first level with pointer', function () {
             var obj = {
                 existing: 'bla'
             };
@@ -90,9 +128,26 @@ describe('json-api', function () {
             obj['first-level'].should.equal('expected');
         });
 
+        it('should work on first level with tokens', function () {
+            var obj = {
+                existing: 'bla'
+            };
+
+            pointer.set(obj, ['first-level'], 'expected');
+            obj['first-level'].should.equal('expected');
+        });
+
         it('should create arrays for numeric reference tokens and objects for other tokens', function () {
             var obj = [];
             pointer.set(obj, '/0/test/0', 'expected');
+            Array.isArray(obj).should.be.true;
+            Array.isArray(obj[0]).should.be.false;
+            Array.isArray(obj[0].test).should.be.true;
+        });
+
+        it('should create arrays for numeric reference tokens and objects for other tokens when tokens are passed', function () {
+            var obj = [];
+            pointer.set(obj, ['0', 'test', '0'], 'expected');
             Array.isArray(obj).should.be.true;
             Array.isArray(obj[0]).should.be.false;
             Array.isArray(obj[0].test).should.be.true;
@@ -107,6 +162,16 @@ describe('json-api', function () {
             obj[1].test.should.have.length(1);
             obj[1].test[0].should.equal('expected');
         });
+
+        it('should create arrays for - and reference the (nonexistent) member after the last array element  when tokens are passed.', function () {
+            var obj = ['foo'];
+            pointer.set(obj, ['-', 'test', '-'], 'expected');
+            Array.isArray(obj).should.be.true;
+            obj.should.have.length(2);
+            Array.isArray(obj[1].test).should.be.true;
+            obj[1].test.should.have.length(1);
+            obj[1].test[0].should.equal('expected');
+        });
     });
 
     describe('#remove', function () {
@@ -115,6 +180,17 @@ describe('json-api', function () {
                 it('should work for "' + p + '"', function () {
                     pointer.remove(rfcExample, p);
                     expect(pointer.get.bind(pointer, rfcExample, p)).to.throw(Error);
+                });
+            }
+        });
+
+        each(Object.keys(rfcParsed), function (p) {
+            if (p !== '') {
+                it('should work for ' + JSON.stringify(rfcParsed[p].tokens), function () {
+                    pointer.remove(rfcExample, rfcParsed[p].tokens);
+                    expect(function() {
+                        pointer.get(pointer, rfcExample, rfcParsed[p].tokens);
+                    }).to.throw(Error);
                 });
             }
         });
@@ -179,6 +255,20 @@ describe('json-api', function () {
             pointer.has(obj, '/bla/test').should.be.true;
         });
 
+        it('should return true when the tokens point to value', function () {
+            var obj = {
+                    bla: {
+                        test: 'expected'
+                    },
+                    foo: [['hello']],
+                    abc: 'bla'
+                };
+            pointer.has(obj, ['bla']).should.be.true;
+            pointer.has(obj, ['abc']).should.be.true;
+            pointer.has(obj, ['foo', '0', '0']).should.be.true;
+            pointer.has(obj, ['bla', 'test']).should.be.true;
+        });
+
         it('should return false when the pointer does not exist', function () {
             var obj = {
                 bla: {
@@ -189,6 +279,20 @@ describe('json-api', function () {
             pointer.has(obj, '/not-existing').should.be.false;
             pointer.has(obj, '/not-existing/bla').should.be.false;
             pointer.has(obj, '/test/1/bla').should.be.false;
+            pointer.has(obj, '/bla/test1').should.be.false;
+        });
+
+        it('should return false when the tokens do not point to value', function () {
+            var obj = {
+                bla: {
+                    test: 'expected'
+                },
+                abc: 'bla'
+            };
+            pointer.has(obj, ['not-existing']).should.be.false;
+            pointer.has(obj, ['not-existing', 'bla']).should.be.false;
+            pointer.has(obj, ['test', '1', 'bla']).should.be.false;
+            pointer.has(obj, ['bla', 'test1']).should.be.false;
         });
     });
 
@@ -243,12 +347,30 @@ describe('convenience api wrapper', function() {
         obj.existing.should.equal('expected');
     });
 
+    it('should call #get when passed 2 args with tokens', function() {
+        var obj = {
+            existing: 'expected'
+        };
+
+        pointer(obj, ['existing']);
+        obj.existing.should.equal('expected');
+    });
+
     it('should call #set when passed 3 args', function() {
         var obj = {
             existing: 'bla'
         };
 
         pointer(obj, '/new-value/bla', 'expected');
+        obj['new-value'].bla.should.equal('expected');
+    });
+
+    it('should call #set when passed 3 args with tokens', function() {
+        var obj = {
+            existing: 'bla'
+        };
+
+        pointer(obj, ['new-value', 'bla'], 'expected');
         obj['new-value'].bla.should.equal('expected');
     });
 
@@ -260,6 +382,8 @@ describe('convenience api wrapper', function() {
 
         objPointer('/new-value/bla', 'expected');
         objPointer('/new-value').bla.should.equal('expected');
+        objPointer(['new-value', 'bla'], 'expected');
+        objPointer(['new-value']).bla.should.equal('expected');
     });
 
     it('should support chainable oo-style', function() {
@@ -268,7 +392,19 @@ describe('convenience api wrapper', function() {
             },
             objPointer = pointer(obj);
 
-        objPointer.set('/oo-style', 'bla').set('/example/0', 'bla');
+        objPointer.set('/oo-style', 'bla').set('/example/0', 'bla2');
         objPointer.get('/oo-style').should.equal('bla');
+        objPointer.get('/example/0').should.equal('bla2');
+    });
+
+    it('should support chainable oo-style with tokens', function() {
+        var obj = {
+                existing: 'bla'
+            },
+            objPointer = pointer(obj);
+
+        objPointer.set(['oo-style'], 'bla').set(['example', '0'], 'bla2');
+        objPointer.get(['oo-style']).should.equal('bla');
+        objPointer.get(['example', '0']).should.equal('bla2');
     });
 });


### PR DESCRIPTION
The reason is that once you've parsed and manipulated a pointer in some way it's kind of wasteful to compile it back to the string to be used with get/set/remove where it will be parsed again.