### PR TITLE
Correctly handle remove from an array

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,18 @@ api.remove = function (obj, pointer) {
     if (finalToken === undefined) {
         throw new Error('Invalid JSON pointer for remove: "' + pointer + '"');
     }
-    delete api.get(obj, refTokens.slice(0, -1))[finalToken];
+
+    var parent = api.get(obj, refTokens.slice(0, -1));
+    if (Array.isArray(parent)) {
+      var index = +finalToken;
+      if (finalToken === '' && isNaN(index)) {
+        throw new Error('Invalid array index: "' + finalToken + '"');
+      }
+
+      Array.prototype.splice.call(parent, index, 1);
+    } else {
+      delete parent[finalToken];
+    }
 };
 
 /**

--- a/test/test.js
+++ b/test/test.js
@@ -177,24 +177,49 @@ describe('json-api', function () {
 
     describe('#remove', function () {
         each(Object.keys(rfcValues), function (p) {
-            if (p !== '') {
-                it('should work for "' + p + '"', function () {
-                    pointer.remove(rfcExample, p);
-                    expect(pointer.get.bind(pointer, rfcExample, p)).to.throw(Error);
-                });
-            }
+            if (p === '' || p === '/foo/0') return;
+
+            it('should work for "' + p + '"', function () {
+                pointer.remove(rfcExample, p);
+                expect(pointer.get.bind(pointer, rfcExample, p)).to.throw(Error);
+            });
+        });
+
+        it('should work for "/foo/0"', function () {
+            var p = '/foo/0';
+            pointer.remove(rfcExample, p);
+            expect(pointer.get(rfcExample, p)).to.equal('baz');
+        });
+
+        it('should work for "/foo/1"', function () {
+            var p = '/foo/1';
+            pointer.remove(rfcExample, p);
+            expect(pointer.get.bind(pointer, rfcExample, p)).to.throw(Error);
         });
 
         each(Object.keys(rfcParsed), function (p) {
-            if (p !== '') {
-                it('should work for ' + JSON.stringify(rfcParsed[p].tokens), function () {
-                    pointer.remove(rfcExample, immutable(rfcParsed[p].tokens));
-                    expect(function() {
-                        pointer.get(rfcExample, immutable(rfcParsed[p].tokens));
-                    }).to.throw(Error);
-                });
-            }
+            if (p === '' || p === '/foo/0') return;
+
+            it('should work for ' + JSON.stringify(rfcParsed[p].tokens), function () {
+                pointer.remove(rfcExample, immutable(rfcParsed[p].tokens));
+                expect(function() {
+                    pointer.get(rfcExample, immutable(rfcParsed[p].tokens));
+                }).to.throw(Error);
+            });
         });
+
+        it('should work for ["foo","0"]', function () {
+            var p = immutable(['foo', '0']);
+            pointer.remove(rfcExample, p);
+            expect(pointer.get(rfcExample, p)).to.equal('baz');
+        });
+
+        it('should work for ["foo","1"]', function () {
+            var p = immutable(['foo', '1']);
+            pointer.remove(rfcExample, p);
+            expect(pointer.get.bind(pointer, rfcExample, p)).to.throw(Error);
+        });
+
     });
 
     describe('#dict', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -190,7 +190,7 @@ describe('json-api', function () {
                 it('should work for ' + JSON.stringify(rfcParsed[p].tokens), function () {
                     pointer.remove(rfcExample, immutable(rfcParsed[p].tokens));
                     expect(function() {
-                        pointer.get(pointer, rfcExample, immutable(rfcParsed[p].tokens));
+                        pointer.get(rfcExample, immutable(rfcParsed[p].tokens));
                     }).to.throw(Error);
                 });
             }


### PR DESCRIPTION
Currently `remove` use `delete parent[finalToken]` both object and arrays.
Here is how  JS interperet `delete` on array:
```
$ node
> a = [1,2,3]
[ 1, 2, 3 ]
> delete a[1]
true
> a
[ 1, , 3 ]
> JSON.stringify(a)
'[1,null,3]'
```
So instead of deleting element `delete` replace it with `null`.

@manuelstofer Can you please review this PR?