### PR TITLE
Throw when try to set the root object

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,6 +69,10 @@ api.set = function set (obj, pointer, value) {
     var refTokens = Array.isArray(pointer) ? pointer : api.parse(pointer),
       nextTok = refTokens[0];
 
+    if (refTokens.length === 0) {
+      throw Error('Can not set the root object');
+    }
+
     for (var i = 0; i < refTokens.length - 1; ++i) {
         var tok = refTokens[i];
         if (tok === '-' && Array.isArray(obj)) {

--- a/test/test.js
+++ b/test/test.js
@@ -101,6 +101,9 @@ describe('json-api', function () {
     });
 
     describe('#set', function () {
+        it('should throw when try to set the root object', function () {
+            expect(pointer.set.bind(pointer, {}, '', 'bla')).to.throw(Error);
+        });
 
         it('should set a value on an object with pointer', function () {
             var obj = {


### PR DESCRIPTION
Before this changes:
```js
var obj = {};
pointer.set(obj, '', 'bla');
console.log(JSON.stringify(obj)); //{"undefined": "bla"}
```