### PR TITLE
URI decode reference tokens

### DIFF
--- a/index.js
+++ b/index.js
@@ -199,7 +199,7 @@ api.escape = function escape (str) {
  * @returns {string}
  */
 api.unescape = function unescape (str) {
-    return str.replace(/~1/g, '/').replace(/~0/g, '~');
+    return decodeURIComponent(str.replace(/~1/g, '/').replace(/~0/g, '~'));
 };
 
 /**


### PR DESCRIPTION
JSON pointer must be a valid URL so it may have URL-encoded symbols. This lib should decode them.

Details: https://github.com/BigstickCarpet/json-schema-ref-parser/issues/44#issuecomment-318471923 and https://github.com/BigstickCarpet/json-schema-ref-parser/pull/90